### PR TITLE
Remove unused variable in setIntegTime function

### DIFF
--- a/src/SparkFun_VEML6030_Ambient_Light_Sensor.cpp
+++ b/src/SparkFun_VEML6030_Ambient_Light_Sensor.cpp
@@ -101,7 +101,7 @@ void SparkFun_Ambient_Light::setIntegTime(uint16_t time){
     return;
 
   _writeRegister(SETTING_REG, INTEG_MASK, bits, INTEG_POS);  
-  uint8_t regVal = readIntegTime();
+  
 
 }
 


### PR DESCRIPTION
Description:
Removed unused variable regVal from the setIntegTime function in the SparkFun VEML6030 library. This variable was storing the result of readIntegTime() but was never used, triggering a compiler warning.
Terminal Error (before fix):
`warning: unused variable 'regVal' [-Wunused-variable]
  uint8_t regVal = readIntegTime();`
  
The warning was correctly flagging that we were assigning a value to regVal but never using it in the code, which is inefficient and could confuse future maintainers. This change helps clean up the code without affecting functionality.